### PR TITLE
adding navigation buttons to sidebar

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "leaflet": "^0.7.7",
     "react": "^0.14.5",
     "react-dom": "^0.14.5",
-    "react-fa": "^4.0.0",
     "react-images": "^0.2.1",
     "react-leaflet": "^0.10.0",
     "react-redux": "^4.0.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "leaflet": "^0.7.7",
     "react": "^0.14.5",
     "react-dom": "^0.14.5",
+    "react-fa": "^4.0.0",
     "react-images": "^0.2.1",
     "react-leaflet": "^0.10.0",
     "react-redux": "^4.0.6",

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -8,8 +8,8 @@ export const SET_FOCUSED_STORY = 'SET_FOCUSED_STORY';
 export const SET_STORIES = 'SET_STORIES';
 
 // action creators
-export function setFocusedStory (story) {
-  return { type: SET_FOCUSED_STORY, story: story };
+export function setFocusedStory (storyId) {
+  return { type: SET_FOCUSED_STORY, story: storyId };
 }
 
 export function setStories (stories) {

--- a/src/actions/actions.js
+++ b/src/actions/actions.js
@@ -9,7 +9,7 @@ export const SET_STORIES = 'SET_STORIES';
 
 // action creators
 export function setFocusedStory (storyId) {
-  return { type: SET_FOCUSED_STORY, story: storyId };
+  return { type: SET_FOCUSED_STORY, storyId: storyId };
 }
 
 export function setStories (stories) {

--- a/src/components/story_container.js
+++ b/src/components/story_container.js
@@ -1,6 +1,5 @@
 import React from "react";
 import { render } from "react-dom";
-import Icon from 'react-fa';
 
 class StoryContainer extends React.Component {
   constructor (props) {
@@ -16,7 +15,6 @@ class StoryContainer extends React.Component {
   render () {
     return (
       <div className="tenant-story-popup">
-        <Icon name="chevron-left" />
         <h2>
           {this.props.story.address}
         </h2>

--- a/src/components/story_container.js
+++ b/src/components/story_container.js
@@ -2,6 +2,16 @@ import React from "react";
 import { render } from "react-dom";
 
 class StoryContainer extends React.Component {
+  constructor (props) {
+    super(props);
+  }
+
+  static propTypes = {
+    focusedStory: React.PropTypes.number.isRequired,
+    stories:      React.PropTypes.array.isRequired,
+    story:        React.PropTypes.object.isRequired
+  };
+
   render () {
     return (
       <div className="tenant-story-popup">

--- a/src/components/story_container.js
+++ b/src/components/story_container.js
@@ -7,17 +7,22 @@ class StoryContainer extends React.Component {
   }
 
   static propTypes = {
-    focusedStory: React.PropTypes.number.isRequired,
-    stories:      React.PropTypes.array.isRequired,
-    story:        React.PropTypes.object.isRequired
+    focusedStory:   React.PropTypes.number.isRequired,
+    stories:        React.PropTypes.array.isRequired,
+    story:          React.PropTypes.object.isRequired,
+    setFocus:       React.PropTypes.func.isRequired
   };
 
   render () {
     return (
-      <div className="tenant-story-popup">
-        <h2>
-          {this.props.story.address}
-        </h2>
+      <div className="story-container">
+        <div id="location-header">
+          {this.renderPreviousButton()}
+          <h2 id="address">
+            {this.props.story.address}
+          </h2>
+          {this.renderNextButton()}
+        </div>
         <h3>
           Owner: {this.props.story.owner}
         </h3>
@@ -27,6 +32,30 @@ class StoryContainer extends React.Component {
         {this.renderVideo()}
       </div>
     );
+  }
+
+  renderPreviousButton () {
+    if ( this.props.focusedStory !== 0 ) {
+      return (
+        <i className="fa fa-chevron-left fa-3x"
+          id="left-nav-button"
+          onClick={this.props.setFocus.bind(this, this.props.focusedStory - 1)} />
+      );
+    } else {
+      return ( <i className="fa fa-chevron-left fa-3x disabled" id="left-nav-button" /> );
+    }
+  }
+
+  renderNextButton () {
+    if ( this.props.focusedStory !== this.props.stories.length - 1) {
+      return (
+        <i className="fa fa-chevron-right fa-3x" 
+          id="right-nav-button"
+          onClick={this.props.setFocus.bind(this, this.props.focusedStory + 1)} />
+      );
+    } else {
+      return ( <i className="fa fa-chevron-right fa-3x disabled" id="right-nav-button" /> );
+    }
   }
 
   renderImages () {

--- a/src/components/story_container.js
+++ b/src/components/story_container.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "react-dom";
+import Icon from 'react-fa';
 
 class StoryContainer extends React.Component {
   constructor (props) {
@@ -15,6 +16,7 @@ class StoryContainer extends React.Component {
   render () {
     return (
       <div className="tenant-story-popup">
+        <Icon name="chevron-left" />
         <h2>
           {this.props.story.address}
         </h2>

--- a/src/components/story_map.js
+++ b/src/components/story_map.js
@@ -47,7 +47,8 @@ class StoryMap extends React.Component {
           <StoryContainer
             focusedStory={focusedStory}
             story={stories[focusedStory]}
-            stories={stories} />
+            stories={stories}
+            setFocus={index => dispatch(setFocusedStory(index))} />
         </Sidebar>
       </div>
     );

--- a/src/components/story_map.js
+++ b/src/components/story_map.js
@@ -44,7 +44,10 @@ class StoryMap extends React.Component {
             }} />
         </Map>
         <Sidebar>
-          <StoryContainer story={stories[focusedStory]} />
+          <StoryContainer
+            focusedStory={focusedStory}
+            story={stories[focusedStory]}
+            stories={stories} />
         </Sidebar>
       </div>
     );

--- a/src/components/story_map.js
+++ b/src/components/story_map.js
@@ -34,8 +34,8 @@ class StoryMap extends React.Component {
           <StoryMarkers
             stories={stories}
             map={this.props.map}
-            handleOnClick={story =>
-              dispatch(setFocusedStory(story))} />
+            handleOnClick={index =>
+              dispatch(setFocusedindex(index))} />
         </Map>
         <Sidebar>
           <StoryContainer story={focusedStory} />

--- a/src/components/story_map.js
+++ b/src/components/story_map.js
@@ -38,7 +38,7 @@ class StoryMap extends React.Component {
               dispatch(setFocusedindex(index))} />
         </Map>
         <Sidebar>
-          <StoryContainer story={focusedStory} />
+          <StoryContainer story={stories[focusedStory]} />
         </Sidebar>
       </div>
     );

--- a/src/components/story_map.js
+++ b/src/components/story_map.js
@@ -22,6 +22,10 @@ class StoryMap extends React.Component {
     eagerLoadImages();
   }
 
+  refreshStoryMap () {
+    this.forceUpdate();
+  }
+
   render() {
     const { dispatch, focusedStory, stories } = this.props;
     return (
@@ -34,8 +38,10 @@ class StoryMap extends React.Component {
           <StoryMarkers
             stories={stories}
             map={this.props.map}
-            handleOnClick={index =>
-              dispatch(setFocusedindex(index))} />
+            handleOnClick={index => {
+              dispatch(setFocusedStory(index));
+              this.refreshStoryMap();
+            }} />
         </Map>
         <Sidebar>
           <StoryContainer story={stories[focusedStory]} />

--- a/src/components/story_marker.js
+++ b/src/components/story_marker.js
@@ -11,13 +11,13 @@ class StoryMarker extends React.Component {
     map:            React.PropTypes.object.isRequired,
     position:       React.PropTypes.array.isRequired,
     handleOnClick:  React.PropTypes.func.isRequired,
-    story:          React.PropTypes.object.isRequired
+    storyId:        React.PropTypes.number.isRequired
   };
 
   render() {
     return (
       <Marker
-        onClick={this.props.handleOnClick.bind(this, this.props.story)}
+        onClick={this.props.handleOnClick.bind(this, this.props.storyId)}
         map={this.props.map}
         position={this.props.position} />
     );

--- a/src/components/story_markers.js
+++ b/src/components/story_markers.js
@@ -21,6 +21,7 @@ class StoryMarkers extends React.Component {
           map={this.props.map}
           position={[story.Latitude, story.Longitude]}
           handleOnClick={this.props.handleOnClick}
+          storyId={index}
           key={index}>
         </StoryMarker>
       )));

--- a/src/components/story_markers.js
+++ b/src/components/story_markers.js
@@ -20,8 +20,7 @@ class StoryMarkers extends React.Component {
         <StoryMarker
           map={this.props.map}
           position={[story.Latitude, story.Longitude]}
-          handleOnClick={this.props.handleOnClick.bind(this, index)}
-          story={story}
+          handleOnClick={this.props.handleOnClick}
           key={index}>
         </StoryMarker>
       )));

--- a/src/components/story_markers.js
+++ b/src/components/story_markers.js
@@ -20,7 +20,7 @@ class StoryMarkers extends React.Component {
         <StoryMarker
           map={this.props.map}
           position={[story.Latitude, story.Longitude]}
-          handleOnClick={this.props.handleOnClick}
+          handleOnClick={this.props.handleOnClick.bind(this, index)}
           story={story}
           key={index}>
         </StoryMarker>

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8" />
 
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css">
 
 </head>
 <body>

--- a/src/map.js
+++ b/src/map.js
@@ -17,7 +17,7 @@ if (document.getElementById('east_boston_tenant_association_map')) {
   let store = createStore(updateMapState);
 
   store.dispatch(setStories(tenantAssociations));
-  store.dispatch(setFocusedStory(store.getState().stories[0]));
+  store.dispatch(setFocusedStory(0));
 
   render(
     <Provider store={store}>

--- a/src/reducers/reducers.js
+++ b/src/reducers/reducers.js
@@ -9,7 +9,7 @@ function updateMapState (state = initialState, action) {
   switch (action.type) {
     case actions.SET_FOCUSED_STORY:
       return Object.assign({}, state, {
-        focusedStory: action.story
+        focusedStory: action.storyId
       });
     case actions.SET_STORIES:
       return Object.assign({}, state, {

--- a/src/stylesheets/main.scss
+++ b/src/stylesheets/main.scss
@@ -1,4 +1,5 @@
 @import "leaflet/leaflet";
+@import "sidebar";
 
 @media screen and (max-width: 768px){
   #map-container {

--- a/src/stylesheets/sidebar.scss
+++ b/src/stylesheets/sidebar.scss
@@ -1,13 +1,27 @@
-#left-nav-button {
-}
+#location-header {
+  padding-top: 10px;
 
-#right-nav-button {
-}
+  #left-nav-button {
+    float: left;
+  }
 
-#address {
-  text-align: center;
-}
+  #right-nav-button {
+    float: right
+  }
 
-i.disabled {
-  color: #F2F2F2;
+  #address {
+    text-align: center;
+    display: inline-block;
+    width: 80%;
+    margin-top: 10px;
+    margin-bottom: 10px;
+  }
+
+  i {
+    display: inline-block;
+  }
+
+  i.disabled {
+    color: #F2F2F2;
+  }
 }

--- a/src/stylesheets/sidebar.scss
+++ b/src/stylesheets/sidebar.scss
@@ -1,0 +1,13 @@
+#left-nav-button {
+}
+
+#right-nav-button {
+}
+
+#address {
+  text-align: center;
+}
+
+i.disabled {
+  color: #F2F2F2;
+}


### PR DESCRIPTION
Building out the sidebar!

First order of business. Previously I was just passing the `story` (basically an object with all the info we want to show for a particular address) into each `StoryMarker`, and then we could bind `onClick` on the `StoryMarker` with the `story` as an argument, `onClick` being a little callback passed in to dispatch the change to the store (so under this schema the `focusedStory` attribute on the store is a story object).

This works well, but it doesn't really support adding other buttons or different ways to move between the active stories. So, I've just refactored it to:
- pass a `storyId` prop to each `StoryMarker` component
- the `setFocusedStory` action takes a `storyId` now
- we initialize the store with `store.dispatch(setFocusedStory(0))`
- the active story is now retrieved by doing `stories[focusedStory]`

I think this improves the situation quite a bit. Our `StoryMarker`'s are still rendered by iterating through the stories (we basically do `this.props.stories.forEach( (story, index) => { do.some.stuff } )`) so we still have the location info and so on right there, but the `StoryMarker` just accepts the `position`, `map`, `handleOnClick`, `storyId`, and `key` props (and so it's a little bit less knowledgable about what `stories` actually are).

Now I think it should be pretty easy to add buttons to the `StoryContainer` component that do the same thing - basically we just pass in the `storyId` and the `stories`, and then we can do some logic to figure out when to put down a `previous` and `next` button, and the buttons have a callback bound to `onClick` that dispatches a `setFocusedStory` action back to the store.

Redux is super awesome and makes managing this kind of state way nice!
