### PR TITLE
fix eager loading of images

### DIFF
--- a/src/components/story_map.js
+++ b/src/components/story_map.js
@@ -5,7 +5,7 @@ import Sidebar from "./sidebar";
 import { setFocusedStory } from "../actions/actions";
 import StoryMarkers from "../components/story_markers";
 import StoryContainer from "../components/story_container";
-import { eagerLoadImages } from "../images/images";
+import Images from "../images/images";
 
 class StoryMap extends React.Component {
   constructor(props) {
@@ -19,7 +19,7 @@ class StoryMap extends React.Component {
   };
 
   componentWillMount () {
-    eagerLoadImages();
+    Images.eagerLoad();
   }
 
   refreshStoryMap () {

--- a/src/data/east_boston_stories.js
+++ b/src/data/east_boston_stories.js
@@ -1,4 +1,4 @@
-import { photos } from "../images/images";
+import Images from "../images/images";
 
 var eastBostonStories = [
   {
@@ -9,7 +9,7 @@ var eastBostonStories = [
     Latitude: 42.369521,
     Longitude: -71.037244,
     images: [
-      photos.maverickStreet17
+      Images.images.maverickStreet17
     ],
     video: "uinevl-LnTI"
   },
@@ -21,8 +21,8 @@ var eastBostonStories = [
     Latitude: 42.370093,
     Longitude: -71.033843,
     images: [
-      photos.goveStreetMailbox,
-      photos.goveStreet
+      Images.images.goveStreetMailbox,
+      Images.images.goveStreet
     ],
     tenantAssociationLetter: ``
   },
@@ -34,7 +34,7 @@ var eastBostonStories = [
     Latitude: 42.370724,
     Longitude: -71.033808,
     images: [
-      photos.lubecStreet
+      Images.images.lubecStreet
     ]
   },
   {
@@ -45,7 +45,7 @@ var eastBostonStories = [
     Latitude: 42.368669,
     Longitude: -71.035611,
     images: [
-      photos.maverickStreet21
+      Images.images.maverickStreet21
     ]
   },
   {
@@ -56,8 +56,8 @@ var eastBostonStories = [
     Latitude: 42.378119,
     Longitude: -71.033425,
     images: [
-      photos.saratogaPorch,
-      photos.saratogaStreet
+      Images.images.saratogaPorch,
+      Images.images.saratogaStreet
     ]
   },
   {
@@ -68,7 +68,7 @@ var eastBostonStories = [
     Latitude: 42.370697,
     Longitude: -71.037756,
     images: [
-      photos.chelseaStreet25
+      Images.images.chelseaStreet25
     ]
   },
   {
@@ -79,7 +79,7 @@ var eastBostonStories = [
     Latitude: 42.387102,
     Longitude: -71.006143,
     images: [
-      photos.benningtonSt
+      Images.images.benningtonSt
     ]
   },
   {
@@ -90,7 +90,7 @@ var eastBostonStories = [
     Latitude: 42.378097,
     Longitude: -71.029607,
     images: [
-      photos.chelseaStreet35
+      Images.images.chelseaStreet35
     ]
   },
   {
@@ -101,7 +101,7 @@ var eastBostonStories = [
     Latitude: 42.377834,
     Longitude: -71.034292,
     images: [
-      photos.brooksSt
+      Images.images.brooksSt
     ]
   }
 ]

--- a/src/images/images.js
+++ b/src/images/images.js
@@ -1,20 +1,24 @@
-export const photos = {
-  benningtonSt: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/10_bennington_st.png",
-  brooksSt: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/10_brooks_st.png",
-  maverickStreet21: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/21_maverick_st.png",
-  maverickStreet17: "https://cdn.rawgit.com/AntiEvictionBoston/utility/7d72d309b144cd5dd25f5ce53563b33472d775eb/images/17_maverick_st.png",
-  saratogaPorch: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/22_saratoga_porch.png",
-  saratogaStreet: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/22_saratoga_street.png",
-  chelseaStreet25: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/25_chelsea_st.png",
-  chelseaStreet35: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/35_chelsea_street.png",
-  lubecStreet: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/64_lubec_street.png",
-  goveStreetMailbox: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/gove_street_mailboxes.png",
-  goveStreet: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/gove_street.png"
-}
+class Images {
+  static images = {
+    benningtonSt: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/10_bennington_st.png",
+    brooksSt: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/10_brooks_st.png",
+    maverickStreet21: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/21_maverick_st.png",
+    maverickStreet17: "https://cdn.rawgit.com/AntiEvictionBoston/utility/7d72d309b144cd5dd25f5ce53563b33472d775eb/images/17_maverick_st.png",
+    saratogaPorch: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/22_saratoga_porch.png",
+    saratogaStreet: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/22_saratoga_street.png",
+    chelseaStreet25: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/25_chelsea_st.png",
+    chelseaStreet35: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/35_chelsea_street.png",
+    lubecStreet: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/64_lubec_street.png",
+    goveStreetMailbox: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/gove_street_mailboxes.png",
+    goveStreet: "https://cdn.rawgit.com/AntiEvictionBoston/utility/master/images/gove_street.png"
+  }
 
-export function eagerLoadImages () {
-  for (let key in Object.keys(photos)) {
-    let i = new Image;
-    i.src = photos[key];
+  static eagerLoad = () => {
+    Object.keys(Images.images).forEach( (key) => {
+      let i = new Image();
+      i.src = Images.images[key];
+    });
   }
 }
+
+export default Images;


### PR DESCRIPTION
this fixes the actually completely non functional eager loading dealio I wrote before >.<

basically we are now storing the image stuff in a class with two static methods, one of which is the object of image urls and the other of which is a little function that iterates through them and sources them each in turn.

This let's us just import `Images` in a top level component (`StoryMap`) and call `Images.eagerLoad()` in the `componentWillMount` hook.
