### PR TITLE
testing out the facebook video integration

### DIFF
--- a/src/components/facebook_video.js
+++ b/src/components/facebook_video.js
@@ -9,7 +9,7 @@ class FacebookVideo extends React.Component {
   render () {
     return (
       <div
-        class="fb-video"
+        className="fb-video"
         data-href={this.props.videoUrl}
         data-allowfullscreen="true"
         data-width="auto">

--- a/src/components/story_media.js
+++ b/src/components/story_media.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { render } from "react-dom";
 import YouTube from "react-youtube";
+import FacebookVideo from "./facebook_video";
 
 class StoryMedia extends React.Component {
   render () {
@@ -137,8 +138,8 @@ class StoryMedia extends React.Component {
     if (this.props.story.video) {
       return (
         <div className="row media-row">
-          <YouTube
-            videoId={this.props.story.video}
+          <FacebookVideo
+            videoUrl={this.props.story.video}
             className="video-container" />
         </div>
       );


### PR DESCRIPTION
this looks for a `video` attribute on the `story` object and, if we have one, instantiates the `FacebookVideo` component on the page with that URL.

by using a component we source the JS for facebook once (on page load) instead of re-sourcing it every time we want to embed a video. this should help performance, although it's still a little sluggish to pop in when you switch to a pin that has a video attached to it
