### PR TITLE
add a map intro

### DIFF
--- a/src/components/story_markers.js
+++ b/src/components/story_markers.js
@@ -17,15 +17,17 @@ class StoryMarkers extends React.Component {
     let markers = [];
     Object.keys(this.props.stories).forEach((k,i) => {
       let story = this.props.stories[k]
-      markers.push(
-        <StoryMarker
-          map={this.props.map}
-          currentUrl={this.props.url}
-          story={story}
-          urlForStory={k}
-          key={i}>
-        </StoryMarker>
-      );
+      if ( story.Latitude && story.Longitude ) {
+        markers.push(
+          <StoryMarker
+            map={this.props.map}
+            currentUrl={this.props.url}
+            story={story}
+            urlForStory={k}
+            key={i}>
+          </StoryMarker>
+        );
+      }
     });
     return (
       <div id="markers">

--- a/src/components/story_media.js
+++ b/src/components/story_media.js
@@ -28,16 +28,18 @@ class StoryMedia extends React.Component {
 
   renderImages () {
     let images = [];
-    if ( this.props.story.images.length > 0 ) {
-      this.props.story.images.forEach((image, index) => (
-        images.push (
-          <div
-            className={"row media-row " + this.setHidingState(index)}
-            key={index}>
-            <img src={image} />
-          </div>
-        )
-      ));
+    if ( this.props.story.images ) {
+      if ( this.props.story.images.length > 0 ) {
+        this.props.story.images.forEach((image, index) => (
+          images.push (
+            <div
+              className={"row media-row " + this.setHidingState(index)}
+              key={index}>
+              <img src={image} />
+            </div>
+          )
+        ));
+      }
     }
     if ( images.length > 1 ) {
       images.push(this.showMoreImagesButton(images.length + 1));

--- a/src/data/east_boston_stories.js
+++ b/src/data/east_boston_stories.js
@@ -1,6 +1,11 @@
 import Images from "../images/images";
 
 let eastBostonStories = {
+  "introduction": {
+    story: `This interactive map of Boston renters’ stories tells a tale of evictions and displacement in our increasingly upscale rental market. Who is getting pushed out as rents rise and higher-income earners move in? These stories don’t represent the scale of no-fault evictions in Boston (complete and accurate data on no-fault evictions not possible to represent at this time), but they begin to illuminate the human impact.* Also, this small sampling of stories is just the start of this project - share your story through the form on this site, and we’ll put you on the map.
+
+    *Pins on map don’t represent exact addresses of tenants but do denote the streets where stories took place.`
+  },
   "east_boston": {
     title: "East Boston",
     type: "neighborhood",


### PR DESCRIPTION
this adds a 'map intro' story that shows up before everything else.

Not quite ready yet, there's a little bit of logic in how we place pins on the map that needs to be sorted. Unless we'd like this intro to also have a pin (which would make things super easy).
